### PR TITLE
Overflow checking for symbolic add/sub

### DIFF
--- a/example/standalone/overflow_symbolic.rs
+++ b/example/standalone/overflow_symbolic.rs
@@ -1,0 +1,7 @@
+fn main() {
+    use std::io::{stdin, Read};
+    let mut data = [0; 1];
+    stdin().read_exact(&mut data[..]).unwrap();
+    let i = data[0] as i8;
+    let _overflowed: i8 = i - 1i8;
+}

--- a/src/operator.rs
+++ b/src/operator.rs
@@ -60,7 +60,13 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
     ) -> EvalResult<'tcx, bool> {
         let (val, overflowed) = self.binop_with_overflow(op, left, right)?;
         self.write_primval(dest, val, dest_ty)?;
-        Ok(overflowed.to_bool()?)
+        if overflowed.is_concrete() {
+            Ok(overflowed.to_bool()?)
+        } else {
+            // keeps the old behavior of ignoring overflow for symbolic ops
+            // this works because the return value is never used
+            Ok(false)
+        }
     }
 }
 

--- a/src/operator.rs
+++ b/src/operator.rs
@@ -25,7 +25,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
         op: mir::BinOp,
         left: &mir::Operand<'tcx>,
         right: &mir::Operand<'tcx>,
-    ) -> EvalResult<'tcx, (PrimVal, bool)> {
+    ) -> EvalResult<'tcx, (PrimVal, PrimVal)> {
         let left_ty    = self.operand_ty(left);
         let right_ty   = self.operand_ty(right);
         let left_val   = self.eval_operand_to_primval(left)?;
@@ -44,7 +44,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
         dest_ty: Ty<'tcx>,
     ) -> EvalResult<'tcx> {
         let (val, overflowed) = self.binop_with_overflow(op, left, right)?;
-        let val = Value::ByValPair(val, PrimVal::from_bool(overflowed));
+        let val = Value::ByValPair(val, overflowed);
         self.write_value(ValTy { value: val, ty: dest_ty}, dest)
     }
 
@@ -60,7 +60,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
     ) -> EvalResult<'tcx, bool> {
         let (val, overflowed) = self.binop_with_overflow(op, left, right)?;
         self.write_primval(dest, val, dest_ty)?;
-        Ok(overflowed)
+        Ok(overflowed.to_bool()?)
     }
 }
 
@@ -68,7 +68,7 @@ macro_rules! overflow {
     ($op:ident, $l:expr, $r:expr) => ({
         let (val, overflowed) = $l.$op($r);
         let primval = PrimVal::Bytes(val as u128);
-        Ok((primval, overflowed))
+        Ok((primval, PrimVal::from_bool(overflowed)))
     })
 }
 
@@ -122,7 +122,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
         left_ty: Ty<'tcx>,
         right: PrimVal,
         right_ty: Ty<'tcx>,
-    ) -> EvalResult<'tcx, (PrimVal, bool)> {
+    ) -> EvalResult<'tcx, (PrimVal, PrimVal)> {
         use rustc::mir::BinOp::*;
         use value::PrimValKind::*;
 
@@ -155,7 +155,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                 Offset if left_kind == Ptr && right_kind == usize => {
                     let pointee_ty = left_ty.builtin_deref(true).expect("Offset called on non-ptr type").ty;
                     let ptr = self.pointer_offset(left, pointee_ty, right.to_bytes()? as i64)?;
-                    return Ok((ptr, false));
+                    return Ok((ptr, PrimVal::from_bool(false)));
                 },
                 // These work on anything
                 Eq if left_kind == right_kind => {
@@ -165,7 +165,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                         (PrimVal::Undef, _) | (_, PrimVal::Undef) => return Err(EvalError::ReadUndefBytes),
                         _ => false,
                     };
-                    return Ok((PrimVal::from_bool(result), false));
+                    return Ok((PrimVal::from_bool(result), PrimVal::from_bool(false)));
                 }
                 Ne if left_kind == right_kind => {
                     let result = match (left, right) {
@@ -174,7 +174,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                         (PrimVal::Undef, _) | (_, PrimVal::Undef) => return Err(EvalError::ReadUndefBytes),
                         _ => true,
                     };
-                    return Ok((PrimVal::from_bool(result), false));
+                    return Ok((PrimVal::from_bool(result), PrimVal::from_bool(false)));
                 }
                 // These need both pointers to be in the same allocation
                 Lt | Le | Gt | Ge | Sub
@@ -200,7 +200,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                             }
                             _ => bug!("We already established it has to be one of these operators."),
                         };
-                        return Ok((PrimVal::from_bool(res), false));
+                        return Ok((PrimVal::from_bool(res), PrimVal::from_bool(false)));
                     } else {
                         // Both are pointers, but from different allocations.
                         return Err(EvalError::InvalidPointerMath);
@@ -297,7 +297,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
             }
         };
 
-        Ok((val, false))
+        Ok((val, PrimVal::from_bool(false)))
     }
 
     fn ptr_int_arithmetic(
@@ -306,11 +306,11 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
         left: MemoryPointer,
         right: i128,
         signed: bool,
-    ) -> EvalResult<'tcx, (PrimVal, bool)> {
+    ) -> EvalResult<'tcx, (PrimVal, PrimVal)> {
         use rustc::mir::BinOp::*;
 
-        fn map_to_primval((res, over) : (MemoryPointer, bool)) -> (PrimVal, bool) {
-            (PrimVal::Ptr(res), over)
+        fn map_to_primval((res, over) : (MemoryPointer, bool)) -> (PrimVal, PrimVal) {
+            (PrimVal::Ptr(res), PrimVal::from_bool(over))
         }
 
         let left_offset = match left.offset {
@@ -332,10 +332,10 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                 let right = right as u64;
                 if right & base_mask == base_mask {
                     // Case 1: The base address bits are all preserved, i.e., right is all-1 there
-                    (PrimVal::Ptr(MemoryPointer::new(left.alloc_id, left_offset & right)), false)
+                    (PrimVal::Ptr(MemoryPointer::new(left.alloc_id, left_offset & right)), PrimVal::from_bool(false))
                 } else if right & base_mask == 0 {
                     // Case 2: The base address bits are all taken away, i.e., right is all-0 there
-                    (PrimVal::from_u128((left_offset & right) as u128), false)
+                    (PrimVal::from_u128((left_offset & right) as u128), PrimVal::from_bool(false))
                 } else {
                     return Err(EvalError::ReadPointerAsBytes);
                 }
@@ -355,7 +355,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
         left_kind: PrimValKind,
         right: PrimVal,
         mut right_kind: PrimValKind,
-    ) -> EvalResult<'tcx, (PrimVal, bool)> {
+    ) -> EvalResult<'tcx, (PrimVal, PrimVal)> {
 
         // These ops can have an RHS with a different numeric type.
         if bin_op == mir::BinOp::Shl || bin_op == mir::BinOp::Shr {
@@ -368,7 +368,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                             for idx in num_bytes .. 8 {
                                 buffer[idx] = abytes[idx - num_bytes];
                             }
-                            return Ok((PrimVal::Abstract(buffer), false));
+                            return Ok((PrimVal::Abstract(buffer), PrimVal::from_bool(false)));
                         }
                         mir::BinOp::Shr => {
                             if !left_kind.is_signed_int() {
@@ -376,7 +376,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                                 for idx in num_bytes .. 8 {
                                     buffer[idx - num_bytes] = abytes[idx];
                                 }
-                                return Ok((PrimVal::Abstract(buffer), false));
+                                return Ok((PrimVal::Abstract(buffer), PrimVal::from_bool(false)));
                             }
                         }
                         _ => unimplemented!(),
@@ -407,7 +407,29 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
             let msg = format!("unimplemented binary op: {:?}, {:?}, {:?}", left, right, bin_op);
             return Err(EvalError::Unimplemented(msg));
         }
-        Ok((self.memory.constraints.add_binop_constraint(bin_op, left, right, left_kind), false))
+
+        use value::PrimValKind::*;
+        match bin_op {
+            mir::BinOp::Add => {
+                let res = self.memory.constraints.add_binop_constraint(bin_op, left, right, left_kind);
+                let overflow = match left_kind {
+                    U8 | U16 | U32 | U64 | U128 => {
+                        self.memory.constraints.add_binop_constraint(mir::BinOp::Lt, res, left, left_kind)
+                    }
+                    I8 | I16 | I32 | I64 | I128 => {
+                        // TODO signed overflow check
+                        PrimVal::from_bool(false)
+                    }
+                    F32 | F64 => {
+                        PrimVal::from_bool(false)
+                    }
+                    Bool | Char | Ptr | FnPtr => unreachable!()
+                };
+                Ok((res, overflow))
+            }
+            // TODO overflow checks on other binops
+            _ => Ok((self.memory.constraints.add_binop_constraint(bin_op, left, right, left_kind), PrimVal::from_bool(false)))
+        }
     }
 
     fn abstract_ptr_ops(
@@ -417,7 +439,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
         _left_kind: PrimValKind,
         right: MemoryPointer,
         _right_kind: PrimValKind,
-    ) -> EvalResult<'tcx, (PrimVal, bool)> {
+    ) -> EvalResult<'tcx, (PrimVal, PrimVal)> {
         use rustc::mir::BinOp::*;
         use value::PrimValKind::*;
         if left.alloc_id != right.alloc_id {
@@ -429,7 +451,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
         } else {
             let result = self.memory.constraints.add_binop_constraint(
                 bin_op, left.offset.as_primval(), right.offset.as_primval(), U64);
-            Ok((result, false))
+            Ok((result, PrimVal::from_bool(false)))
         }
     }
 

--- a/src/operator.rs
+++ b/src/operator.rs
@@ -417,7 +417,36 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                         self.memory.constraints.add_binop_constraint(mir::BinOp::Lt, res, left, left_kind)
                     }
                     I8 | I16 | I32 | I64 | I128 => {
-                        self.abstract_signed_add_overflowed(left, left_kind, right, right_kind, res)
+                        // The basic idea is
+                        // ```
+                        // both positive => overflow = res < 0
+                        // both negative => overflow = res > 0
+                        // _ => false
+                        // ```
+                        // Using only supported operations, this becomes
+                        // ```
+                        // if left >= 0 {
+                        //     if right >= 0 {
+                        //         res < 0
+                        //     } else {
+                        //         false
+                        //     }
+                        // } else {
+                        //     if right >= 0 {
+                        //         false
+                        //     } else {
+                        //         res >= 0
+                        //     }
+                        // }
+                        // ```
+                        let zero = PrimVal::from_i128(0);
+                        let left_positive = self.memory.constraints.add_binop_constraint(mir::BinOp::Ge, left, zero, left_kind);
+                        let right_positive = self.memory.constraints.add_binop_constraint(mir::BinOp::Ge, right, zero, right_kind);
+                        let res_positive = self.memory.constraints.add_binop_constraint(mir::BinOp::Ge, res, zero, left_kind);
+                        let res_negative = self.memory.constraints.add_unop_constraint(mir::UnOp::Not, res_positive, Bool);
+                        let left_positive_then = self.memory.constraints.add_if_then_else(right_positive, Bool, res_negative, PrimVal::from_bool(false));
+                        let left_positive_else = self.memory.constraints.add_if_then_else(right_positive, Bool, PrimVal::from_bool(false), res_positive);
+                        self.memory.constraints.add_if_then_else(left_positive, Bool, left_positive_then, left_positive_else)
                     }
                     F32 | F64 => PrimVal::from_bool(false),
                     Bool | Char | Ptr | FnPtr => unreachable!(),
@@ -431,8 +460,17 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                         self.memory.constraints.add_binop_constraint(mir::BinOp::Gt, res, left, left_kind)
                     }
                     I8 | I16 | I32 | I64 | I128 => {
-                        let right_neg = self.memory.constraints.add_unop_constraint(mir::UnOp::Neg, right, right_kind);
-                        self.abstract_signed_add_overflowed(left, left_kind, right_neg, right_kind, res)
+                        // same idea as for Add, but we first negate right
+                        // negation can lead to overflow, so we replace the bool right_positive
+                        // with right_negative
+                        let zero = PrimVal::from_i128(0);
+                        let left_positive = self.memory.constraints.add_binop_constraint(mir::BinOp::Ge, left, zero, left_kind);
+                        let right_negative = self.memory.constraints.add_binop_constraint(mir::BinOp::Lt, right, zero, right_kind);
+                        let res_positive = self.memory.constraints.add_binop_constraint(mir::BinOp::Ge, res, zero, left_kind);
+                        let res_negative = self.memory.constraints.add_unop_constraint(mir::UnOp::Not, res_positive, Bool);
+                        let left_positive_then = self.memory.constraints.add_if_then_else(right_negative, Bool, res_negative, PrimVal::from_bool(false));
+                        let left_positive_else = self.memory.constraints.add_if_then_else(right_negative, Bool, PrimVal::from_bool(false), res_positive);
+                        self.memory.constraints.add_if_then_else(left_positive, Bool, left_positive_then, left_positive_else)
                     }
                     F32 | F64 => PrimVal::from_bool(false),
                     Bool | Char | Ptr | FnPtr => unreachable!(),
@@ -441,50 +479,6 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
             }
             _ => Ok((self.memory.constraints.add_binop_constraint(bin_op, left, right, left_kind), PrimVal::from_bool(false)))
         }
-    }
-
-    /// Returns an abstract PrimVal that is true if the signed operation `left + right` overflows.
-    ///
-    /// `res` is assumed to be the result of `left + right`.
-    fn abstract_signed_add_overflowed(
-        &mut self,
-        left: PrimVal,
-        left_kind: PrimValKind,
-        right: PrimVal,
-        right_kind: PrimValKind,
-        res: PrimVal
-    ) -> PrimVal {
-        // The basic idea is
-        // ```
-        // both positive => overflow = res < 0
-        // both negative => overflow = res > 0
-        // _ => false
-        // ```
-        // Using only supported operations, this becomes
-        // ```
-        // if left >= 0 {
-        //     if right >= 0 {
-        //         res < 0
-        //     } else {
-        //         false
-        //     }
-        // } else {
-        //     if right >= 0 {
-        //         false
-        //     } else {
-        //         res >= 0
-        //     }
-        // }
-        // ```
-        use value::PrimValKind::*;
-        let zero = PrimVal::from_i128(0);
-        let left_positive = self.memory.constraints.add_binop_constraint(mir::BinOp::Ge, left, zero, left_kind);
-        let right_positive = self.memory.constraints.add_binop_constraint(mir::BinOp::Ge, right, zero, right_kind);
-        let res_positive = self.memory.constraints.add_binop_constraint(mir::BinOp::Ge, res, zero, left_kind);
-        let res_negative = self.memory.constraints.add_unop_constraint(mir::UnOp::Not, res_positive, Bool);
-        let left_positive_then = self.memory.constraints.add_if_then_else(right_positive, Bool, res_negative, PrimVal::from_bool(false));
-        let left_positive_else = self.memory.constraints.add_if_then_else(right_positive, Bool, PrimVal::from_bool(false), res_positive);
-        self.memory.constraints.add_if_then_else(left_positive, Bool, left_positive_then, left_positive_else)
     }
 
     fn abstract_ptr_ops(

--- a/tests/symbolic/manticore.rs
+++ b/tests/symbolic/manticore.rs
@@ -13,7 +13,7 @@ fn check_char_0(mut ch: u8) -> Result<(), ()> {
 
 fn check_char_1(mut ch: u8) -> Result<(), ()> {
     ch ^= 107;
-    ch += 67;
+    ch = ch.wrapping_add(67);
 
     if ch == 105 {
         Ok(())
@@ -23,7 +23,7 @@ fn check_char_1(mut ch: u8) -> Result<(), ()> {
 }
 
 fn check_char_2(mut ch: u8) -> Result<(), ()> {
-    ch += 61;
+    ch = ch.wrapping_add(61);
     ch *= 2;
 
     if ch == 252 {
@@ -66,7 +66,7 @@ fn check_char_5(mut ch: u8) -> Result<(), ()> {
 }
 
 fn check_char_6(mut ch: u8) -> Result<(), ()> {
-    ch += 71;
+    ch = ch.wrapping_add(71);
 
     if ch == 138 {
         Ok(())
@@ -86,8 +86,8 @@ fn check_char_7(mut ch: u8) -> Result<(), ()> {
 }
 
 fn check_char_8(mut ch: u8) -> Result<(), ()> {
-    ch += 41;
-    ch += 53;
+    ch = ch.wrapping_add(41);
+    ch = ch.wrapping_add(53);
 
     if ch == 176 {
         Ok(())
@@ -98,8 +98,8 @@ fn check_char_8(mut ch: u8) -> Result<(), ()> {
 
 fn check_char_9(mut ch: u8) -> Result<(), ()> {
     ch ^= 61;
-    ch += 41;
-    ch += 11;
+    ch = ch.wrapping_add(41);
+    ch = ch.wrapping_add(11);
 
     if ch == 172 {
         Ok(())
@@ -110,8 +110,8 @@ fn check_char_9(mut ch: u8) -> Result<(), ()> {
 
 fn check_char_10(mut ch: u8) -> Result<(), ()> {
     ch ^= 47;
-    ch += 29;
-    ch += 67;
+    ch = ch.wrapping_add(29);
+    ch = ch.wrapping_add(67);
 
     if ch == 114 {
         Ok(())

--- a/tests/symbolic/ptr_offset.rs
+++ b/tests/symbolic/ptr_offset.rs
@@ -11,7 +11,7 @@ fn main() {
     let d0 = data[0]; // 2
     let d1 = data[1]; // 4
 
-    if (d0 + d1) as usize >= v.len() {
+    if (d0.wrapping_add(d1)) as usize >= v.len() {
         return;
     }
 

--- a/tests/symbolic/write_mem.rs
+++ b/tests/symbolic/write_mem.rs
@@ -10,11 +10,11 @@ fn main() {
     // should panic on [ 7, 3, 21, 21 ]
 
     if data.len() >= 4 {
-        let mut v = [0; BUFFER_LENGTH];
-        v[0] += data[3];
-        v[1] = v[0] + data[2];
+        let mut v: [u8; BUFFER_LENGTH] = [0; BUFFER_LENGTH];
+        v[0] = v[0].wrapping_add(data[3]);
+        v[1] = v[0].wrapping_add(data[2]);
         if v[0] == 21 && v[1] == 42 {
-            v[0] = data[0] + data[1];
+            v[0] = data[0].wrapping_add(data[1]);
             v[3] = data[0];
             if v[3] == 7 && v[0] == 10 {
                 panic!()


### PR DESCRIPTION
This adds overflow checks for abstract addition and subtraction. `intrinsic_with_overflow` can now store an abstract `PrimVal` for the overflow bool. This allows the compiler-inserted `Asserts` to be evaluated meaningfully for `Add` and `Sub` with at least one abstract operand.

Some of the function signatures in operator.rs have been changed: instead of returning a `bool` to indicate overflow, a `PrimVal` is used. This allows us to return abstract values when needed.

I ran into some trouble with tests failing because `intrinsic_overflowing` had to return a `bool`. If the overflow `PrimVal` is abstract, conversion to `bool` is `unimplemented!()`. The workaround returns to the old behavior of just returning false (no overflow) for all abstract ops. From a quick search of the codebase, it seems like none of the users of the function actually use the returned overflow bool. It might be a better solution to just remove the overflow bool from the return value.

A few other tests failed because Seer stops at the first panic, which ended up being an overflow. I replaced the adds with `wrapping_add`, which prevents the insertion of overflow checks.