### PR TITLE
Allow consumers to continue on error

### DIFF
--- a/src/executor.rs
+++ b/src/executor.rs
@@ -154,6 +154,7 @@ impl <'a, 'tcx: 'a> Executor<'a, 'tcx> {
                         let iter = ::std::iter::repeat(ecx).zip(branches.into_iter());
                         for (mut cx, finish_step) in iter {
                             let FinishStep {constraints, variant} = finish_step;
+                            let mut no_errors: bool = true;
                             for constraint in constraints {
                                 cx.memory.constraints.push_constraint(constraint);
                                 match variant {
@@ -169,10 +170,14 @@ impl <'a, 'tcx: 'a> Executor<'a, 'tcx> {
                                         if !self.report_error(&cx, e.clone()) {
                                             break 'main_loop;
                                         }
+                                        no_errors = false;
                                     }
                                 }
                             }
-                            self.push_eval_context(cx);
+                            if no_errors {
+                                // only continue along branches without errors
+                                self.push_eval_context(cx);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
If Seer is configured with a consumer that wants to continue execution when encountering errors (a consumer that always returns `true`), it repeatedly reports the same error. This is because the unmodified `EvalContext` is pushed back on the stack in the main loop in the error case. This fixes the problem.